### PR TITLE
GRAPHN-16 - Add built script triggered after npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "dist/scripts.js",
   "scripts": {
+    "build": "npm run build:prod",
     "build:dev": "webpack --mode=development --config webpack.dev.config.js",
     "build:prod": "webpack --mode=production --config webpack.prod.config.js",
     "build:example": "webpack --mode=production --config webpack.example.config.js",


### PR DESCRIPTION
**Business justification:** https://trello.com/c/vDlvqg7H/16-graphn-15-add-built-script-triggered-after-npm-install

**Description:** When installing `graphn` as a dependency, build script must be invoked. Official documentation https://docs.npmjs.com/cli/build.html.

