### PR TITLE
GRAPHN-17 - Fix built script triggered after npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/scripts.js",
   "scripts": {
-    "build": "npm run build:prod",
+    "postinstall": "npm run build:prod",
     "build:dev": "webpack --mode=development --config webpack.dev.config.js",
     "build:prod": "webpack --mode=production --config webpack.prod.config.js",
     "build:example": "webpack --mode=production --config webpack.example.config.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/scripts.js",
   "scripts": {
-    "postinstall": "npm run build:prod",
+    "prepublish": "webpack --mode=production --config webpack.prod.config.js",
     "build:dev": "webpack --mode=development --config webpack.dev.config.js",
     "build:prod": "webpack --mode=production --config webpack.prod.config.js",
     "build:example": "webpack --mode=production --config webpack.example.config.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/scripts.js",
   "scripts": {
-    "prepublish": "webpack --mode=production --config webpack.prod.config.js",
+    "prepare": "webpack --mode=production --config webpack.prod.config.js",
     "build:dev": "webpack --mode=development --config webpack.dev.config.js",
     "build:prod": "webpack --mode=production --config webpack.prod.config.js",
     "build:example": "webpack --mode=production --config webpack.example.config.js",


### PR DESCRIPTION
**Business justification:** https://trello.com/c/Zd54PJQP/17-graphn-17-fix-built-script-triggered-after-npm-install

**Description:** Apparently `npm build` is not triggered after `npm install`, hence another hook needs to be used.

