### PR TITLE
CODA-45 - Link component styles are not added

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -19,6 +19,7 @@
 @import "components/Led/styles/mixins";
 @import "components/Led/styles/styles";
 @import "components/List/styles/styles";
+@import "components/Link/styles/styles";
 @import "components/Loader/styles/styles";
 @import "components/Navigation/styles/styles";
 @import "components/Panel/styles/styles";


### PR DESCRIPTION
**Business justification:** https://trello.com/c/JzhCYXPT/45-coda-45-link-component-styles-are-not-added

**Description:** `Link` component styles are not added by mistake. This PR adds the styles.

