### PR TITLE
CODA-55 - Cleanup naming and improve styling

### DIFF
--- a/src/components/Alert/styles/_styles.scss
+++ b/src/components/Alert/styles/_styles.scss
@@ -4,20 +4,20 @@
     padding: $spacing-large $spacing-medium;
 
     &--danger {
-        color: $gb-brand-color-danger;
-        border-color: $gb-brand-color-danger;
-        background-color: $gb-brand-color-danger-soft;
+        color: $gb-color-danger;
+        border-color: $gb-color-danger;
+        background-color: $gb-color-danger-soft;
     }
 
     &--success {
-        color: $gb-brand-color-success;
-        border-color: $gb-brand-color-success;
-        background-color: $gb-brand-color-success-soft;
+        color: $gb-color-success;
+        border-color: $gb-color-success;
+        background-color: $gb-color-success-soft;
     }
 
     &--info {
-        color: $gb-brand-color-info;
-        border-color: $gb-brand-color-info;
-        background-color: $gb-brand-color-info-soft;
+        color: $gb-color-info;
+        border-color: $gb-color-info;
+        background-color: $gb-color-info-soft;
     }
 }

--- a/src/components/Body/Footer/styles/_styles.scss
+++ b/src/components/Body/Footer/styles/_styles.scss
@@ -4,7 +4,7 @@
     margin-top: 20px;
 
     &--default {
-        background-color: $gb-brand-color-component;
+        background-color: $gb-color-component;
     }
 }
 

--- a/src/components/Body/Header/styles/_styles.scss
+++ b/src/components/Body/Header/styles/_styles.scss
@@ -2,8 +2,8 @@
     display: flex;
 
     &--default {
-        background-color:$gb-brand-color-component;
-        border-bottom: 1px solid $gb-brand-color-component-dark;
+        background-color:$gb-color-component;
+        border-bottom: 1px solid $gb-color-component-dark;
     }
 
     &__logo {

--- a/src/components/Body/styles/_styles.scss
+++ b/src/components/Body/styles/_styles.scss
@@ -6,10 +6,10 @@
     display: flex;
     flex-direction: column;
     margin: 0;
-    font-family: $gb-brand-font;
+    font-family: $gb-font;
     font-weight: 100;
     font-size: $font-size-very-large;
-    color: $gb-brand-color-text;
+    color: $gb-color-text;
 
     a {
         cursor: pointer;

--- a/src/components/Button/styles/_styles.scss
+++ b/src/components/Button/styles/_styles.scss
@@ -26,18 +26,18 @@
     }
 
     &--default {
-        @include cx-btn--hover($gb-brand-color-component, $gb-brand-color-text);
+        @include cx-btn--hover($gb-color-component, $gb-color-text);
     }
 
-    &--accept {
-        @include cx-btn--hover($gb-brand-color-success, $color-white);
+    &--success {
+        @include cx-btn--hover($gb-color-success, $color-white);
     }
 
-    &--edit {
-        @include cx-btn--hover($gb-brand-color-info, $color-white);
+    &--info {
+        @include cx-btn--hover($gb-color-info, $color-white);
     }
 
-    &--remove {
-        @include cx-btn--hover($gb-brand-color-danger, $color-white);
+    &--danger {
+        @include cx-btn--hover($gb-color-danger, $color-white);
     }
 }

--- a/src/components/Card/styles/_styles.scss
+++ b/src/components/Card/styles/_styles.scss
@@ -10,7 +10,7 @@
     margin: 2px;
 
     &--default {
-        background-color: $gb-brand-color-component;
-        border-color: $gb-brand-color-component-dark;
+        background-color: $gb-color-component;
+        border-color: $gb-color-component-dark;
     }
 }

--- a/src/components/Input/styles/_styles.scss
+++ b/src/components/Input/styles/_styles.scss
@@ -27,7 +27,7 @@
         padding: 0px $spacing-medium;
         font-size: $font-size-very-large;
         line-height: $font-line-height-normal;
-        border: 1px solid $gb-brand-color-component-dark;
+        border: 1px solid $gb-color-component-dark;
     }
 }
 

--- a/src/components/Led/styles/_styles.scss
+++ b/src/components/Led/styles/_styles.scss
@@ -2,9 +2,9 @@ $gc-led-red-center: #f00;
 $gc-led-green-center: #0f0;
 $gc-led-blue-center: #b5f2e4;
 
-@include cx-led-blink (gc-led-red-blink, $gc-led-red-center, $gb-brand-color-danger, $gb-brand-color-danger, rgba(255, 0, 0, 0.5))
-@include cx-led-blink (gc-led-green-blink, $gc-led-green-center, $gb-brand-color-success, $gb-brand-color-success, rgba(0, 255, 0, 0.5))
-@include cx-led-blink (gc-led-blue-blink, $gc-led-blue-center, $gb-brand-color-info, $gb-brand-color-info, rgba(0, 0, 255, 0.5))
+@include cx-led-blink (gc-led-red-blink, $gc-led-red-center, $gb-color-danger, $gb-color-danger, rgba(255, 0, 0, 0.5))
+@include cx-led-blink (gc-led-green-blink, $gc-led-green-center, $gb-color-success, $gb-color-success, rgba(0, 255, 0, 0.5))
+@include cx-led-blink (gc-led-blue-blink, $gc-led-blue-center, $gb-color-info, $gb-color-info, rgba(0, 0, 255, 0.5))
 
 .gc-led {
     display: inline-block;
@@ -14,7 +14,7 @@ $gc-led-blue-center: #b5f2e4;
     border-radius: 50%;
 
     &--red {
-        @include cx-led($gc-led-red-center, $gb-brand-color-danger);
+        @include cx-led($gc-led-red-center, $gb-color-danger);
 
         &.gc-led--blink {
             animation: gc-led-red-blink 0.5s infinite;
@@ -22,7 +22,7 @@ $gc-led-blue-center: #b5f2e4;
     }
 
     &--green {
-        @include cx-led($gc-led-green-center, $gb-brand-color-success);
+        @include cx-led($gc-led-green-center, $gb-color-success);
 
         &.gc-led--blink {
             animation: gc-led-green-blink 0.5s infinite;
@@ -30,7 +30,7 @@ $gc-led-blue-center: #b5f2e4;
     }
 
     &--blue {
-        @include cx-led($gc-led-blue-center, $gb-brand-color-info);
+        @include cx-led($gc-led-blue-center, $gb-color-info);
 
         &.gc-led--blink {
             animation: gc-led-blue-blink 0.5s infinite;

--- a/src/components/Link/styles/_styles.scss
+++ b/src/components/Link/styles/_styles.scss
@@ -1,9 +1,9 @@
 .gc-link {
-    color: $gb-brand-color-link;
+    color: $gb-color-link;
     cursor: pointer;
     text-decoration: none;
 
     &:hover {
-        color: lighten($gb-brand-color-link, 20%);
+        color: lighten($gb-color-link, 20%);
     }
 }

--- a/src/components/List/styles/_styles.scss
+++ b/src/components/List/styles/_styles.scss
@@ -8,6 +8,6 @@
         padding: $spacing-large 1.5 * $spacing-large;
         margin-bottom: -1px;
         background-color: $color-white;
-        border: 1px solid $gb-brand-color-component-dark;
+        border: 1px solid $gb-color-component-dark;
     }
 }

--- a/src/components/Navigation/styles/_styles.scss
+++ b/src/components/Navigation/styles/_styles.scss
@@ -14,7 +14,7 @@
     }
 
     &--default {
-        color: $gb-brand-color-text;
+        color: $gb-color-text;
 
         .gc-navigation__link {
             &:hover {

--- a/src/components/Panel/styles/_styles.scss
+++ b/src/components/Panel/styles/_styles.scss
@@ -1,12 +1,12 @@
 .gc-panel {
-    background-color: $gb-brand-color-background;
+    background-color: $gb-color-background;
 
     &--separator {
-        border-bottom: 1px dashed $gb-brand-color-separator;
+        border-bottom: 1px dashed $gb-color-separator;
     }
 
     &--bordered {
-        border: 1px solid $gb-brand-color-separator;
+        border: 1px solid $gb-color-separator;
     }
 
     &__title {

--- a/src/components/Sample/styles/_styles.scss
+++ b/src/components/Sample/styles/_styles.scss
@@ -2,34 +2,34 @@
     @include gx-sample(40px);
 
     &--brand-primary {
-        @include gx-sample--color($gb-brand-color-primary);
+        @include gx-sample--color($gb-color-primary);
     }
 
     &--brand-text {
-        @include gx-sample--color($gb-brand-color-text);
+        @include gx-sample--color($gb-color-text);
     }
 
     &--brand-link {
-        @include gx-sample--color($gb-brand-color-link);
+        @include gx-sample--color($gb-color-link);
     }
 
     &--brand-component {
-        @include gx-sample--color($gb-brand-color-component);
+        @include gx-sample--color($gb-color-component);
     }
 
     &--brand-component-dark {
-     @include gx-sample--color($gb-brand-color-component-dark);
+     @include gx-sample--color($gb-color-component-dark);
     }
 
     &--brand-success {
-        @include gx-sample--color($gb-brand-color-success);
+        @include gx-sample--color($gb-color-success);
     }
 
     &--brand-info {
-     @include gx-sample--color($gb-brand-color-info);
+     @include gx-sample--color($gb-color-info);
     }
 
     &--brand-danger {
-     @include gx-sample--color($gb-brand-color-danger);
+     @include gx-sample--color($gb-color-danger);
     }
 }

--- a/src/components/Scroller/styles/_styles.scss
+++ b/src/components/Scroller/styles/_styles.scss
@@ -4,8 +4,8 @@ $gc-scroller-size: 12px;
   position: relative;
   border-width: 1px;
   border-style: solid;
-  border-color: $gb-brand-color-component-dark;
-  background-color: $gb-brand-color-component;
+  border-color: $gb-color-component-dark;
+  background-color: $gb-color-component;
   border-radius: $radius-small;
   height: $gc-scroller-size;
 

--- a/src/components/Switch/styles/_mixins.scss
+++ b/src/components/Switch/styles/_mixins.scss
@@ -2,7 +2,7 @@ $gx-switch-btn-size: 26px;
 
 @mixin gx-switch() {
     $parent-selector: &;
-    border: 1px solid $gb-brand-color-separator;
+    border: 1px solid $gb-color-separator;
     position: relative;
     display: inline-block;
     width: 60px;
@@ -14,7 +14,7 @@ $gx-switch-btn-size: 26px;
 
         &:checked {
             & + #{$parent-selector}__slider {
-                background-color: $gb-brand-color-component;
+                background-color: $gb-color-component;
             }
 
             & + #{$parent-selector}__slider::before {
@@ -23,7 +23,7 @@ $gx-switch-btn-size: 26px;
         }
 
         &:focus + #{$parent-selector}__slider {
-            box-shadow: 0 0 1px $gb-brand-color-component;
+            box-shadow: 0 0 1px $gb-color-component;
         }
     }
 
@@ -34,7 +34,7 @@ $gx-switch-btn-size: 26px;
         right: 0;
         bottom: 0;
         cursor: pointer;
-        background-color: $gb-brand-color-component;
+        background-color: $gb-color-component;
         border-radius: $radius-medium;
         transition: .4s;
 

--- a/src/components/Switch/styles/_styles.scss
+++ b/src/components/Switch/styles/_styles.scss
@@ -3,14 +3,14 @@
     @include gx-switch();
 
     &--success {
-        @include gx-switch--color($root-selector, $gb-brand-color-success);
+        @include gx-switch--color($root-selector, $gb-color-success);
     }
 
     &--info {
-        @include gx-switch--color($root-selector, $gb-brand-color-info);
+        @include gx-switch--color($root-selector, $gb-color-info);
     }
 
     &--danger {
-        @include gx-switch--color($root-selector, $gb-brand-color-danger);
+        @include gx-switch--color($root-selector, $gb-color-danger);
     }
 }

--- a/src/components/Textarea/styles/_styles.scss
+++ b/src/components/Textarea/styles/_styles.scss
@@ -3,7 +3,7 @@
     min-height: 35px;
     padding: $spacing-medium $spacing-medium;
     width: 100%;
-    border: 1px solid $gb-brand-color-component-dark;
+    border: 1px solid $gb-color-component-dark;
     font-size: $font-size-very-large;
     line-height: $font-line-height-normal;
     border-radius: $radius-medium;

--- a/src/example.jsx
+++ b/src/example.jsx
@@ -15,35 +15,35 @@ if (appContainer) {
           <ul className="gc-list">
             <li className="gc-list__item">
               <div className="tst-colors-primary gc-sample gc-sample--brand-primary" />{" "}
-              - Brand color primary / $gb-brand-color-primary
+              - Brand color primary / $gb-color-primary
             </li>
             <li className="gc-list__item">
               <div className="tst-colors-text gc-sample gc-sample--brand-text" />{" "}
-              - Brand color text / $gb-brand-color-text
+              - Brand color text / $gb-color-text
             </li>
             <li className="gc-list__item">
               <div className="tst-colors-link gc-sample gc-sample--brand-link" />{" "}
-              - Brand color link / $gb-brand-color-link
+              - Brand color link / $gb-color-link
             </li>
             <li className="gc-list__item">
               <div className="tst-colors-component gc-sample gc-sample--brand-component" />{" "}
-              - Brand color component / $gb-brand-color-component
+              - Brand color component / $gb-color-component
             </li>
             <li className="gc-list__item">
               <div className="tst-colors-component gc-sample gc-sample--brand-component-dark" />{" "}
-              - Brand color component dark / $gb-brand-color-component-dark
+              - Brand color component dark / $gb-color-component-dark
             </li>
             <li className="gc-list__item">
               <div className="gc-sample gc-sample--brand-success" /> - Brand
-              color success / $gb-brand-color-success
+              color success / $gb-color-success
             </li>
             <li className="gc-list__item">
               <div className="gc-sample gc-sample--brand-info" /> - Brand color
-              info / $gb-brand-color-info
+              info / $gb-color-info
             </li>
             <li className="gc-list__item">
               <div className="gc-sample gc-sample--brand-danger" /> - Brand
-              color danger / $gb-brand-color-danger
+              color danger / $gb-color-danger
             </li>
           </ul>
         </div>
@@ -149,23 +149,23 @@ if (appContainer) {
           <p>
             <button className="gc-btn">Button</button>{" "}
             <button className="gc-btn gc-btn--default">Button + default</button>{" "}
-            <button className="gc-btn gc-btn--accept">Button + accept</button>{" "}
-            <button className="gc-btn gc-btn--edit">Button + edit</button>{" "}
-            <button className="gc-btn gc-btn--remove">Button + remove</button>
+            <button className="gc-btn gc-btn--success">Button + success</button>{" "}
+            <button className="gc-btn gc-btn--info">Button + info</button>{" "}
+            <button className="gc-btn gc-btn--danger">Button + danger</button>
           </p>
           <p>
             <button className="gc-btn gc-btn--small">Button + small</button>{" "}
             <button className="gc-btn gc-btn--small gc-btn--default">
               Button + small + default
             </button>{" "}
-            <button className="gc-btn gc-btn--small gc-btn--accept">
-              Button + small + accept
+            <button className="gc-btn gc-btn--small gc-btn--success">
+              Button + small + success
             </button>{" "}
-            <button className="gc-btn gc-btn--small gc-btn--edit">
-              Button + small + edit
+            <button className="gc-btn gc-btn--small gc-btn--info">
+              Button + small + info
             </button>{" "}
-            <button className="gc-btn gc-btn--small gc-btn--remove">
-              Button + small + remove
+            <button className="gc-btn gc-btn--small gc-btn--danger">
+              Button + small + danger
             </button>
           </p>
           <p>
@@ -177,18 +177,18 @@ if (appContainer) {
             </button>
           </p>
           <p>
-            <button className="gc-btn gc-btn--full gc-btn--accept">
-              Button + full + accept
+            <button className="gc-btn gc-btn--full gc-btn--success">
+              Button + full + success
             </button>
           </p>
           <p>
-            <button className="gc-btn gc-btn--full gc-btn--edit">
-              Button + full + edit
+            <button className="gc-btn gc-btn--full gc-btn--info">
+              Button + full + info
             </button>
           </p>
           <p>
-            <button className="gc-btn gc-btn--full gc-btn--remove">
-              Button + full + remove
+            <button className="gc-btn gc-btn--full gc-btn--danger">
+              Button + full + danger
             </button>
           </p>
         </div>
@@ -286,13 +286,13 @@ if (appContainer) {
             <div className="gc-alert">Alert</div>
           </p>
           <p>
-            <div className="gc-alert gc-alert--danger">Alert + danger</div>
-          </p>
-          <p>
             <div className="gc-alert gc-alert--success">Alert + success</div>
           </p>
           <p>
             <div className="gc-alert gc-alert--info">Alert + info</div>
+          </p>
+          <p>
+            <div className="gc-alert gc-alert--danger">Alert + danger</div>
           </p>
         </div>
       </article>

--- a/src/variables/_brand.scss
+++ b/src/variables/_brand.scss
@@ -1,23 +1,23 @@
 /* Colors */
 
 /* Brand role */
-$gb-brand-color-background: $color-white !default;
-$gb-brand-color-primary: $color-persian-green !default;
-$gb-brand-color-text: $color-mine-shaft !default;
-$gb-brand-color-link: $color-astral !default;
+$gb-color-background: $color-white !default;
+$gb-color-primary: $color-persian-green !default;
+$gb-color-text: $color-mine-shaft !default;
+$gb-color-link: $color-astral !default;
 
 /* Structural role */
-$gb-brand-color-separator: $color-mercury !default;
-$gb-brand-color-component: $color-wild-sand !default;
-$gb-brand-color-component-dark: $color-mercury !default;
+$gb-color-separator: $color-mercury !default;
+$gb-color-component: $color-wild-sand !default;
+$gb-color-component-dark: $color-mercury !default;
 
 /* Functional role */
-$gb-brand-color-success: $color-persian-green !default;
-$gb-brand-color-success-soft: $color-ice-cold !default;
-$gb-brand-color-info: $color-viking !default;
-$gb-brand-color-info-soft: $color-link-water !default;
-$gb-brand-color-danger: $color-roman !default;
-$gb-brand-color-danger-soft: $color-beauty-bush !default;
+$gb-color-success: $color-persian-green !default;
+$gb-color-success-soft: $color-ice-cold !default;
+$gb-color-info: $color-astral !default;
+$gb-color-info-soft: $color-link-water !default;
+$gb-color-danger: $color-roman !default;
+$gb-color-danger-soft: $color-beauty-bush !default;
 
 /* Fonts */
-$gb-brand-font: Arial !default;
+$gb-font: Arial !default;


### PR DESCRIPTION
**Business justification:** https://trello.com/c/gSbxc9Sg/55-coda-55-cleanup-naming-and-improve-styling

**Description:** Remove `*-brand-*` in-fix in brand variables as it's redundant. Change blue info color and rename all blocks to use consistent semantic names related with the colors.
