### PR TITLE
CODA-62 - Make message in validation input optional

### DIFF
--- a/src/components/Validation/index.jsx
+++ b/src/components/Validation/index.jsx
@@ -7,19 +7,23 @@ type Props = {
   className?: string,
   children?: React$Element<any>,
   type?: string,
-  message?: string
+  message?: string | null
 };
 
 function Validation(props: Props) {
   const { message, children, className, type } = props;
   const validationClasses = classNames(className, "gc-validation");
 
+  const tooltip = message ? (
+    <Tooltip className="gc-validation__message" type={type}>
+      {message}
+    </Tooltip>
+  ) : null;
+
   return (
     <div className={validationClasses}>
       {children}
-      <Tooltip className="gc-validation__message" type={type}>
-        {message}
-      </Tooltip>
+      {tooltip}
     </div>
   );
 }


### PR DESCRIPTION
**Business justification:** https://trello.com/c/0oxaoTuQ/62-coda-make-message-in-validation-input-optional

**Description:** When message is not passed or `null` tooltip should not be rendered.
