### PR TITLE
CODA-75 - Add sub-menu component

### DIFF
--- a/src/components/Dialog/styles/_styles.scss
+++ b/src/components/Dialog/styles/_styles.scss
@@ -8,5 +8,5 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%) !important;
-    box-shadow: 0px 0px 5px 0px rgba(0,0,0,0.38);
+    box-shadow: $gc-shadow-default;
 }

--- a/src/components/Navigation/styles/_styles.scss
+++ b/src/components/Navigation/styles/_styles.scss
@@ -11,6 +11,12 @@
             border-color: $gb-color-primary;
             box-shadow: 0px 1px 0px 0px $gb-color-primary;
         }
+
+        &:hover {
+            .gc-navigation__suboption {
+                display: block;
+            }
+        }
     }
 
     &__link {

--- a/src/components/Navigation/styles/_submenu.scss
+++ b/src/components/Navigation/styles/_submenu.scss
@@ -1,0 +1,22 @@
+.gc-submenu {
+    display: none;
+    position: absolute;
+    background-color: transparent;
+
+    &__content {
+        padding: 10px;
+        border-radius: $radius-medium;
+        border-top: 2px solid $gb-color-primary;
+        margin-top: 7px;
+        box-shadow: $gc-shadow-default;
+        z-index: $zlayer-top;
+        background-color: $color-white;
+    }
+
+    &__item {
+        display: block;
+        padding-left: $spacing-large;
+        padding-right: $spacing-large;
+        line-height: $font-line-height-large;
+    }
+}

--- a/src/example.jsx
+++ b/src/example.jsx
@@ -140,8 +140,18 @@ class ExampleApp extends React.PureComponent<Props, State> {
                   </li>
                   <li className="gc-navigation__option gc-navigation__option--active">
                     <Link className="gc-navigation__link" link="/">
-                      Item 2
+                      Deep Item 2
                     </Link>
+                    <div className="gc-navigation__suboption gc-submenu">
+                      <div className="gc-submenu__content">
+                        <Link className="gc-submenu__item" link="/">
+                          Sub Item 2a
+                        </Link>
+                        <Link className="gc-submenu__item" link="/">
+                          Sub Item 2b
+                        </Link>
+                      </div>
+                    </div>
                   </li>
                   <li className="gc-navigation__option">
                     <Link className="gc-navigation__link" link="/">
@@ -174,8 +184,18 @@ class ExampleApp extends React.PureComponent<Props, State> {
                   </li>
                   <li className="gc-navigation__option gc-navigation__option--active">
                     <Link className="gc-navigation__link" link="/">
-                      Item 2
+                      Deep Item 2
                     </Link>
+                    <div className="gc-navigation__suboption gc-submenu">
+                      <div className="gc-submenu__content">
+                        <Link className="gc-submenu__item" link="/">
+                          Sub Item 2a
+                        </Link>
+                        <Link className="gc-submenu__item" link="/">
+                          Sub Item 2b
+                        </Link>
+                      </div>
+                    </div>
                   </li>
                   <li className="gc-navigation__option">
                     <Link className="gc-navigation__link" link="/">

--- a/src/style.scss
+++ b/src/style.scss
@@ -4,6 +4,7 @@
 @import "variables/typography";
 @import "variables/responsiveness";
 @import "variables/brand";
+@import "variables/shadows";
 
 @import "mixins/responsiveness";
 
@@ -27,6 +28,7 @@
 @import "components/Link/styles/styles";
 @import "components/Loader/styles/styles";
 @import "components/Navigation/styles/styles";
+@import "components/Navigation/styles/submenu";
 @import "components/Panel/styles/styles";
 @import "components/Sample/styles/mixins";
 @import "components/Sample/styles/styles";

--- a/src/variables/_shadows.scss
+++ b/src/variables/_shadows.scss
@@ -1,0 +1,1 @@
+$gc-shadow-default: 0 0 5px 0 rgba(0, 0, 0, 0.38);

--- a/src/variables/_typography.scss
+++ b/src/variables/_typography.scss
@@ -4,6 +4,7 @@ $font-size-large: 12px;
 $font-size-very-large: 14px;
 
 $font-line-height-normal: 1.42857;
+$font-line-height-large: 1.8;
 
 $gc-font-url: './assets/font' !default;
 


### PR DESCRIPTION
**Business justification:** https://trello.com/c/YAGlNWdU/75-coda-75-add-sub-menu-component

**Description:** When one of nested navigation items is hovered, render sub-menu.

<img width="179" alt="Zrzut ekranu 2020-05-21 o 18 01 19" src="https://user-images.githubusercontent.com/3702926/82578765-231cb780-9b8d-11ea-91e0-c51841bb34e2.png">