### PR TITLE
CODA-307 - Remove margin for dropdown without label

### DIFF
--- a/src/components/Dropdown/styles/_styles.scss
+++ b/src/components/Dropdown/styles/_styles.scss
@@ -16,13 +16,16 @@
     font-size: inherit;
     padding: $spacing-large;
     width: 250px;
-    margin-top: 5px;
     margin-bottom: 0;
     position: relative;
     background-color: $color-white;
     color: $gb-color-text;
     border: 1px solid $color-silver;
     border-radius: $radius-medium;
+
+    &--with-label {
+      margin-top: 5px;
+    }
 
     &:hover {
       cursor: pointer;


### PR DESCRIPTION
**Business justification:** https://trello.com/c/meXrrA1r/307-coda-307-remove-margin-for-dropdown-without-label

**Description:** Bug fix.
