### PR TITLE
CODA-76 - Add toggle component to demo page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# CLAUDE.md
+# AGENTS.md
 
 ## Scope
 

--- a/docs/adr/0001-extract-and-own-reusable-components.md
+++ b/docs/adr/0001-extract-and-own-reusable-components.md
@@ -1,0 +1,44 @@
+# ADR 0001: Extract and own reusable Graphen components
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-12
+
+## Context
+
+Graphen is a shared UI library. Component changes can affect multiple downstream applications through React exports, CSS class names, SCSS variables, mixins, bundled assets, and generated documentation.
+
+Reusable UI can become harder to maintain when behavior, styles, example-only markup, and public exports are changed without a clear ownership boundary. A component may start as a small addition to the example app or as repeated markup inside another component, but once it represents a reusable UI primitive it needs the same structure and compatibility expectations as the rest of the library.
+
+## Decision
+
+Reusable UI primitives should be extracted into named components under `src/components/<Component>`.
+
+Each public component should keep its React implementation in `src/components/<Component>/index.tsx`. Component styles should live under `src/components/<Component>/styles/` and be imported from `src/style.scss`.
+
+Public component classes use BEM with the `gc-` prefix. Variants should be represented as modifiers such as `gc-btn--primary` rather than unrelated class names. Component-specific styles should reuse existing branding variables, mixins, shadows, sizes, typography, and responsiveness helpers before adding new tokens.
+
+When a component becomes part of the public package API, export it from `src/index.ts` and update TypeScript declaration coverage in `src/index.d.ts` when needed. New or changed public usage patterns should be represented in the example app so they can be reviewed visually and exercised by integration tests.
+
+Extract a component when a UI section has one or more of these properties:
+
+- It is reused or likely to be reused by downstream applications.
+- It has meaningful variants, state, accessibility behavior, or event handling.
+- It owns a stable BEM block and style contract.
+- It would otherwise add unrelated complexity to another component or the example app.
+
+Do not extract tiny one-off markup that has no independent behavior, style contract, or reuse value. Do not move application-specific workflows, product copy, routing, data fetching, or business rules into Graphen components.
+
+## Consequences
+
+Graphen components keep a predictable structure, making exports, styles, examples, and generated package output easier to review.
+
+The public CSS and React API remain visible during review, which reduces accidental downstream breaking changes.
+
+Some additions require updates in multiple places: component implementation, styles, `src/style.scss`, exports, declarations, examples, and tests. That cost is acceptable for reusable primitives because it keeps package behavior explicit.
+
+Refactors should preserve existing component props, exported symbols, CSS class names, SCSS variables, mixins, and generated assets unless the change is intentionally breaking and documented in the PR.

--- a/src/example.tsx
+++ b/src/example.tsx
@@ -15,6 +15,7 @@ import {
   SegmentedControl,
   Separator,
   Stat,
+  Switch,
   constants,
 } from "./index";
 
@@ -196,6 +197,7 @@ const NAV = [
       { id: "segmented-control", label: "Segmented control" },
       { id: "stat", label: "Stat" },
       { id: "cover-empty", label: "Cover empty" },
+      { id: "switch", label: "Switch" },
     ],
   },
 ];
@@ -221,6 +223,7 @@ const TOC = [
   ["segmented-control", "Segmented control"],
   ["stat", "Stat"],
   ["cover-empty", "Cover empty"],
+  ["switch", "Switch"],
 ] as const;
 
 type IconProps = {
@@ -1207,6 +1210,30 @@ function App() {
               <div className="docs-cover-empty-stage">
                 <CoverEmpty />
               </div>
+            </Demo>
+          </section>
+
+          <section className="docs-section" id="switch">
+            <div className="docs-section-eyebrow">Components / 15</div>
+            <h2 className="docs-section-title">Switch</h2>
+            <p className="docs-section-desc">
+              A toggle for a single on / off setting that takes effect
+              immediately. The <code>type</code> prop colors the active state to
+              match the semantic palette.
+            </p>
+            <Demo
+              stageClass="center"
+              code={`<Switch onChange={(isSwitched) => console.log(isSwitched)} />
+<Switch isSwitched />
+<Switch isSwitched type="success" />
+<Switch isSwitched type="info" />
+<Switch isSwitched type="danger" />`}
+            >
+              <Switch />
+              <Switch isSwitched />
+              <Switch isSwitched type="success" />
+              <Switch isSwitched type="info" />
+              <Switch isSwitched type="danger" />
             </Demo>
           </section>
 


### PR DESCRIPTION
**Business justification:** https://codait.atlassian.net/browse/CODA-76

**Description:**

- Added a **Switch** section to the example/demo page (`src/example.tsx`): navigation and table-of-contents entries plus a demo showing the default, `isSwitched`, and semantic `type` variants (`success`, `info`, `danger`) with a usage code snippet. No changes to the `Switch` component itself — no public API or style contract changes.
- Repository guideline updates included on this branch: rewrote `CLAUDE.md` to reflect Graphen's library conventions (prefixes `gc-`/`gb-`/`gm-`/`gx-`/`cx-`, compatibility rules, check commands), added a matching `AGENTS.md`, and added ADR `docs/adr/0001-extract-and-own-reusable-components.md`.
- No dependency changes.

**Visual overview:**

The new demo section renders five `Switch` states (off, on, and on with `success`/`info`/`danger` types) under "Components / Switch" in the example app (`make example`). Screenshot could not be attached from the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)