### PR TITLE
CODA-79 - Fix navigation sub-menu on mobiles

### DIFF
--- a/src/components/Navigation/styles/_styles.scss
+++ b/src/components/Navigation/styles/_styles.scss
@@ -7,6 +7,7 @@
 
   &__option {
     display: inline-block;
+    position: relative;
     border-bottom: 3px solid transparent;
 
     &--active {
@@ -14,7 +15,7 @@
     }
 
     &:hover {
-      .gc-navigation__suboption {
+      .gc-submenu {
         display: block;
       }
     }

--- a/src/components/Navigation/styles/_submenu.scss
+++ b/src/components/Navigation/styles/_submenu.scss
@@ -1,8 +1,15 @@
 .gc-submenu {
   display: none;
   position: absolute;
+  top: 100%;
+  left: 0;
   background-color: transparent;
   z-index: $zlayer-top;
+
+  @include gx-phone {
+    left: auto;
+    right: 0;
+  }
 
   &__content {
     padding: 10px;


### PR DESCRIPTION
**Business justification:** https://codait.atlassian.net/browse/CODA-79

**Description:** On narrow (phone-width) viewports, `.gc-submenu` overflowed off the right edge of the screen whenever its trigger option sat near the right side of the nav bar (e.g. a "Platforma" tab near the end of the bar), clipping the submenu's items. Fixed by:
- Adding `position: relative` to `.gc-navigation__option` so its submenu anchors to the trigger itself rather than an unpredictable ancestor.
- Making `.gc-submenu`'s default position explicit (`top: 100%; left: 0`) instead of relying on browser static-position fallback.
- Adding a `gx-phone` breakpoint override (`left: auto; right: 0`) so on narrow screens the submenu's right edge locks to its trigger's right edge and expands leftward, staying within the viewport.
- Fixed the hover-reveal rule in `_styles.scss`, which targeted a nonexistent `.gc-navigation__suboption` class instead of `.gc-submenu` (markup and `_submenu.scss` both use `.gc-submenu`), so the built-in hover-to-reveal never fired at all.

No public component API, exported symbols, or class names changed — this is a pure style-contract fix within the existing `.gc-navigation`/`.gc-submenu` classes. `:hover`-only reveal is left as-is (Graphen is intentionally zero-JS; host apps are expected to own their own open/close interaction if `:hover` alone isn't sufficient on touch).

**Visual overview:** Verified via the example app's Navigation section by hovering the "Components" submenu trigger and inspecting bounding rects:
- Default (desktop-width): `submenu.left === option.left` (unchanged left-aligned behavior).
- With the phone-width rule forced active: `submenu.right === option.right` (previously it expanded rightward past the trigger and off-screen — now it hugs the trigger's right edge, matching the reported bug).