### PR TITLE
CODA-81 - Fix submenu position in scrollable navigation

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'cypress'
 export default defineConfig({
   video: false,
   e2e: {
+    baseUrl: `http://localhost:${process.env.PORT || 3000}`,
     setupNodeEvents(on, config) {},
     specPattern: 'src/**/integration/**/*.spec.js',
     testIsolation: false,

--- a/docs/adr/0002-js-anchored-fixed-submenu-positioning.md
+++ b/docs/adr/0002-js-anchored-fixed-submenu-positioning.md
@@ -1,0 +1,36 @@
+# ADR 0002: JS-anchored fixed positioning for the navigation submenu
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-13
+
+## Context
+
+`Navigation` renders a single horizontal row (`white-space: nowrap`), so consumers place it inside a horizontally scrollable header container on narrow viewports. The submenu opened by `NavigationOption` was styled with `position: absolute` and no offsets.
+
+Two constraints shaped earlier iterations (CODA-79):
+
+- The submenu must not have a positioned ancestor inside `gc-navigation`, because consumer headers with `overflow` would clip it.
+- Submenu open state lives in JS (`NavigationOption`), not in CSS hover.
+
+Without a positioned ancestor, an absolutely positioned submenu resolves to its static position. When the consumer scrolls the navigation row horizontally, the submenu renders where the parent option sits in the scrolled content and gets clipped at the viewport edge instead of staying visible under its parent.
+
+## Decision
+
+The submenu is anchored with JavaScript and rendered with `position: fixed`.
+
+On open, `NavigationOption` measures the trigger with `getBoundingClientRect()` and applies inline `top`/`left` to `.gc-submenu`: `top` is the trigger's bottom edge, `left` is the trigger's left edge clamped to the viewport with a 10px margin (matching `$spacing-large`). While the submenu is open, the component listens to `resize` and capture-phase `scroll` events on `window` — the capture phase catches scrolling inside consumer overflow containers — and repositions the submenu.
+
+The submenu stays in the DOM inside its `<li>` (no portal), so the existing blur-based focus containment and Escape handling keep working unchanged. The public component API, class names, and markup structure are unchanged.
+
+## Consequences
+
+The submenu follows its parent option in any scroll container and never overflows the viewport, because `position: fixed` positions against the viewport regardless of ancestor overflow.
+
+The CODA-79 constraint still holds: `gc-submenu` must not gain a positioned ancestor inside `gc-navigation`, and its coordinates are owned by `NavigationOption`, so stylesheets must not set `top`/`left` on it.
+
+New constraint for consumers: an ancestor with `transform`, `filter`, `backdrop-filter`, or similar properties becomes the containing block for `position: fixed` and breaks submenu positioning. Consumer headers wrapping `Navigation` must not apply such properties to ancestors of the navigation.

--- a/example-server/index.js
+++ b/example-server/index.js
@@ -15,4 +15,4 @@ router.get("/", (ctx) => {
 app.use(router.routes()).use(router.allowedMethods());
 app.use(serve(`${__dirname}/../public`));
 
-app.listen(3000, () => {});
+app.listen(process.env.PORT || 3000, () => {});

--- a/src/components/Dropdown/integration/dropdown.spec.js
+++ b/src/components/Dropdown/integration/dropdown.spec.js
@@ -1,6 +1,6 @@
 describe("dropdown menu", () => {
   it("should open dropdown and pick a value", () => {
-    cy.visit("http://localhost:3000");
+    cy.visit("/");
 
     cy.get("#dropdown").scrollIntoView();
 

--- a/src/components/Navigation/styles/_submenu.scss
+++ b/src/components/Navigation/styles/_submenu.scss
@@ -1,6 +1,6 @@
 .gc-submenu {
   display: none;
-  position: absolute;
+  position: fixed;
   background-color: transparent;
   z-index: $zlayer-top;
 

--- a/src/components/NavigationOption/index.tsx
+++ b/src/components/NavigationOption/index.tsx
@@ -1,5 +1,7 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useLayoutEffect, useRef, useState } from "react";
 import classNames from "classnames";
+
+const SUBMENU_VIEWPORT_MARGIN = 10;
 
 type Props = {
   className?: string;
@@ -17,10 +19,51 @@ function NavigationOption({
   children = null,
 }: Props) {
   const [isOpened, setIsOpened] = useState(false);
+  const [submenuPosition, setSubmenuPosition] = useState({ top: 0, left: 0 });
+  const triggerReference = useRef<HTMLButtonElement>(null);
+  const submenuReference = useRef<HTMLDivElement>(null);
 
   const toggleSubmenu = useCallback(() => {
     setIsOpened((previousIsOpened) => !previousIsOpened);
   }, [setIsOpened]);
+
+  const updateSubmenuPosition = useCallback(() => {
+    const trigger = triggerReference.current;
+    const submenu = submenuReference.current;
+
+    if (!trigger || !submenu) {
+      return;
+    }
+
+    const triggerRect = trigger.getBoundingClientRect();
+    const maximumLeft =
+      window.innerWidth - submenu.offsetWidth - SUBMENU_VIEWPORT_MARGIN;
+
+    setSubmenuPosition({
+      top: triggerRect.bottom,
+      left: Math.max(
+        SUBMENU_VIEWPORT_MARGIN,
+        Math.min(triggerRect.left, maximumLeft)
+      ),
+    });
+  }, [setSubmenuPosition]);
+
+  useLayoutEffect(() => {
+    if (!isOpened) {
+      return undefined;
+    }
+
+    updateSubmenuPosition();
+
+    // capture phase catches scrolling inside consumer overflow containers
+    window.addEventListener("scroll", updateSubmenuPosition, true);
+    window.addEventListener("resize", updateSubmenuPosition);
+
+    return () => {
+      window.removeEventListener("scroll", updateSubmenuPosition, true);
+      window.removeEventListener("resize", updateSubmenuPosition);
+    };
+  }, [isOpened, updateSubmenuPosition]);
 
   const closeSubmenuOnBlur = useCallback(
     (event: React.FocusEvent<HTMLLIElement>) => {
@@ -65,6 +108,7 @@ function NavigationOption({
       onKeyDown={closeSubmenuOnEscape}
     >
       <button
+        ref={triggerReference}
         type="button"
         className="gc-navigation__link"
         aria-haspopup="true"
@@ -73,7 +117,11 @@ function NavigationOption({
       >
         {label}
       </button>
-      <div className={submenuClasses}>
+      <div
+        ref={submenuReference}
+        className={submenuClasses}
+        style={{ top: submenuPosition.top, left: submenuPosition.left }}
+      >
         <div className="gc-submenu__content">{children}</div>
       </div>
     </li>

--- a/src/components/NavigationOption/integration/navigation-option.spec.js
+++ b/src/components/NavigationOption/integration/navigation-option.spec.js
@@ -1,0 +1,30 @@
+describe("navigation submenu", () => {
+  it("should anchor submenu to its parent option in a scrolled navigation", () => {
+    cy.visit("/");
+
+    cy.get("#navigation").scrollIntoView();
+
+    cy.get("#navigation .gc-navigation")
+      .eq(1)
+      .parent()
+      .scrollTo("right")
+      .within(() => {
+        cy.contains("button.gc-navigation__link", "Platform").click();
+      });
+
+    cy.window().then((win) => {
+      cy.contains("button.gc-navigation__link", "Platform").then(($trigger) => {
+        const triggerRect = $trigger[0].getBoundingClientRect();
+
+        cy.get(".gc-submenu--opened").then(($submenu) => {
+          const submenuRect = $submenu[0].getBoundingClientRect();
+
+          expect(submenuRect.top).to.be.closeTo(triggerRect.bottom, 1);
+          expect(submenuRect.left).to.be.at.most(triggerRect.left + 1);
+          expect(submenuRect.left).to.be.at.least(0);
+          expect(submenuRect.right).to.be.at.most(win.innerWidth);
+        });
+      });
+    });
+  });
+});

--- a/src/example.tsx
+++ b/src/example.tsx
@@ -1190,6 +1190,43 @@ function App() {
                 <NavigationOption label="Resources" href="#" />
               </Navigation>
             </Demo>
+            <p className="docs-section-desc">
+              Inside a narrow container the navigation scrolls horizontally. The
+              submenu follows its scrolled parent option and stays within the
+              viewport.
+            </p>
+            <Demo
+              stageClass="column"
+              code={`<div style={{ maxWidth: 280, overflowX: "auto" }}>
+  <Navigation>
+    <NavigationOption label="Overview" href="#" isActive />
+    <NavigationOption label="Admin" href="#" />
+    <NavigationOption label="Platform">
+      <a className="gc-submenu__item" href="#">Users</a>
+      <a className="gc-submenu__item" href="#">Events</a>
+    </NavigationOption>
+    <NavigationOption label="e-Shop" href="#" />
+    <NavigationOption label="Account" href="#" />
+  </Navigation>
+</div>`}
+            >
+              <div style={{ maxWidth: 280, overflowX: "auto" }}>
+                <Navigation>
+                  <NavigationOption label="Overview" href="#" isActive />
+                  <NavigationOption label="Admin" href="#" />
+                  <NavigationOption label="Platform">
+                    <a className="gc-submenu__item" href="#">
+                      Users
+                    </a>
+                    <a className="gc-submenu__item" href="#">
+                      Events
+                    </a>
+                  </NavigationOption>
+                  <NavigationOption label="e-Shop" href="#" />
+                  <NavigationOption label="Account" href="#" />
+                </Navigation>
+              </div>
+            </Demo>
           </section>
 
           <section className="docs-section" id="segmented-control">

--- a/src/variables/integration/colors.spec.js
+++ b/src/variables/integration/colors.spec.js
@@ -1,6 +1,6 @@
 describe("Colors", () => {
   before(() => {
-    cy.visit("http://localhost:3000");
+    cy.visit("/");
   });
 
   it("should make a screenshot", () => {


### PR DESCRIPTION
**Business justification:** 

https://codait.atlassian.net/browse/CODA-81

**Description:**

When the navigation is wrapped in a horizontally scrollable container (mobile headers), an opened submenu rendered at its parent option's static position and was clipped at the viewport edge. `.gc-submenu` was `position: absolute` with no offsets and — deliberately, after CODA-79 — no positioned ancestor inside `gc-navigation`, so it could not follow the scrolled parent.

The submenu is now JS-anchored: `NavigationOption` measures the trigger with `getBoundingClientRect()` on open, renders `.gc-submenu` with `position: fixed` and inline `top`/`left` clamped to the viewport (10px margin), and repositions on `resize` and capture-phase `scroll` so scrolling inside consumer overflow containers is tracked. The submenu stays inside its `<li>` (no portal), so the existing blur/Escape close behavior is unchanged.

- Public API: no changes to props, exports, or class names. `.gc-submenu` switches from `position: absolute` to `position: fixed` with component-owned inline coordinates; stylesheets must not set `top`/`left` on it. New consumer constraint: ancestors of the navigation must not use `transform`/`filter`/`backdrop-filter` (they would become the containing block for `fixed`). Rationale recorded in ADR `docs/adr/0002-js-anchored-fixed-submenu-positioning.md`.
- Example app: added a scrollable-navigation demo with a submenu to the Navigation section.
- Tests: new Cypress spec asserts the submenu anchors to its scrolled parent and stays inside the viewport. Test infra: the example server port is now configurable via `PORT` (was hardcoded to 3000, which made `make integration-test` fail when the port is occupied); Cypress gets a matching `baseUrl` and specs use relative visits.

**Visual overview:**

Verified in the example app: with the navigation scrolled inside a narrow wrapper, the submenu opens exactly under its parent option (measured: submenu left/top equal trigger left/bottom) and stays within the viewport. Screenshot to be attached manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)