### PR TITLE
CODA-109 - Sidebar component

### DIFF
--- a/docs/adr/0003-sidebar-navigation-component.md
+++ b/docs/adr/0003-sidebar-navigation-component.md
@@ -1,0 +1,32 @@
+# ADR 0003: Sidebar navigation component family
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-26
+
+## Context
+
+`Navigation` and `NavigationOption` cover horizontal, top-of-page navigation. Application shells built on Graphen increasingly need a vertical, left-hand navigation rail: grouped sections, per-item icons, counts and badges, an active state, a bottom-pinned footer, and an optional collapsed icons-only mode.
+
+Reusing `Navigation` was rejected — it is a single `white-space: nowrap` row whose submenu positioning (ADR 0002) is specific to horizontal, scrollable headers, and stretching it to a vertical rail would overload its API and markup.
+
+## Decision
+
+Add a dedicated, composable `Sidebar` family that mirrors the `Navigation` / `NavigationOption` split and shares a single BEM block (`gc-sidebar`), the same convention `NavigationOption` uses against `gc-navigation`:
+
+- `Sidebar` — the `<nav>` rail container. `isCollapsed` toggles `gc-sidebar--collapsed`, which shrinks the rail, hides group labels and item text/counts/badges, and reveals a hover tooltip per item.
+- `SidebarGroup` — a titled section (`gc-sidebar__group`, `gc-sidebar__group-label`).
+- `SidebarOption` — an item (`gc-sidebar__option`). Renders an `<a>` when `href` is set, otherwise a `<button type="button">`. Supports `icon`, `isActive` (adds the accent bar and `aria-current="page"`), `count`, `badge`, and `onClick`.
+- `SidebarFooter` — a bottom-pinned section (`gc-sidebar__footer`, pushed down with `margin-top: auto`).
+
+Styling reuses existing Graphen tokens (`$gb-color-primary`, `$gb-color-info-soft`, `$gb-color-component`, `$gb-color-separator`, `$gb-color-success`, spacing/radius/shadow/mono-font variables) rather than introducing new design tokens; only the two rail widths are component-local SCSS values. All four components are exported from `src/index.ts` and their styles imported from `src/style.scss`.
+
+## Consequences
+
+Graphen gains a reusable left-sidebar primitive that composes like the rest of the library and inherits brand tokens automatically. The public surface grows by four exports and one new `gc-sidebar` class namespace, all additive — no existing component, class, or variable changes, so downstream compatibility is preserved.
+
+Collapse is a presentational prop only; consumers own active state and any responsive show/hide of the rail. Because the collapsed tooltip and active accent bar are plain CSS (no fixed positioning), the ADR 0002 containing-block constraint does not apply here.

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import classNames from "classnames";
+
+type Props = {
+  className?: string;
+  ariaLabel?: string;
+  isCollapsed?: boolean;
+  children?: React.ReactNode;
+};
+
+function Sidebar({
+  className = "",
+  ariaLabel = "Sidebar",
+  isCollapsed = false,
+  children = null,
+}: Props) {
+  const sidebarClasses = classNames(className, "gc-sidebar", {
+    "gc-sidebar--collapsed": isCollapsed,
+  });
+
+  return (
+    <nav className={sidebarClasses} aria-label={ariaLabel}>
+      {children}
+    </nav>
+  );
+}
+
+export default Sidebar;

--- a/src/components/Sidebar/styles/_styles.scss
+++ b/src/components/Sidebar/styles/_styles.scss
@@ -134,6 +134,10 @@ $gc-sidebar-width-collapsed: 72px;
 
   &--collapsed {
     width: $gc-sidebar-width-collapsed;
+    // `overflow-y: auto` on the block forces `overflow-x` to compute to
+    // `auto` as well, which would clip the hover tooltip at the rail edge.
+    // Collapsed rails hold few items, so drop scrolling to let tips escape.
+    overflow: visible;
 
     .gc-sidebar__group-label {
       height: 8px;

--- a/src/components/Sidebar/styles/_styles.scss
+++ b/src/components/Sidebar/styles/_styles.scss
@@ -151,10 +151,23 @@ $gc-sidebar-width-collapsed: 72px;
       padding: 0;
     }
 
-    .gc-sidebar__option-label,
     .gc-sidebar__option-count,
     .gc-sidebar__option-badge {
       display: none;
+    }
+
+    // Hide the label visually but keep it in the accessibility tree so the
+    // icon-only option still exposes an accessible name to screen readers.
+    .gc-sidebar__option-label {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
     }
 
     .gc-sidebar__option:hover .gc-sidebar__option-tip {

--- a/src/components/Sidebar/styles/_styles.scss
+++ b/src/components/Sidebar/styles/_styles.scss
@@ -1,0 +1,173 @@
+$gc-sidebar-width: 264px;
+$gc-sidebar-width-collapsed: 72px;
+
+.gc-sidebar {
+  display: flex;
+  flex-direction: column;
+  width: $gc-sidebar-width;
+  padding: $spacing-large;
+  background-color: $color-white;
+  border-right: 1px solid $gb-color-separator;
+  overflow-y: auto;
+  transition: width 0.18s ease;
+
+  &__group {
+    margin-top: $spacing-very-large;
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  &__group-label {
+    padding: $spacing-medium $spacing-large $spacing-small;
+    font-family: $gb-font-mono;
+    font-size: $font-size-medium;
+    font-weight: 600;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    color: $gb-color-disabled;
+  }
+
+  &__option {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: $spacing-large;
+    width: 100%;
+    height: 39px;
+    padding: 0 $spacing-large;
+    border: 0;
+    border-radius: $radius-medium;
+    background: none;
+    color: $gb-color-text;
+    font: inherit;
+    font-weight: 600;
+    text-align: left;
+    text-decoration: none;
+    cursor: pointer;
+    transition:
+      background-color 0.12s ease,
+      color 0.12s ease;
+
+    &:hover {
+      background-color: $gb-color-component;
+      color: $gb-color-text;
+      text-decoration: none;
+    }
+
+    &--active {
+      background-color: $gb-color-info-soft;
+      color: $gb-color-primary;
+
+      &::before {
+        content: "";
+        position: absolute;
+        left: -#{$spacing-large};
+        top: 8px;
+        bottom: 8px;
+        width: 3px;
+        border-radius: 0 3px 3px 0;
+        background-color: $gb-color-primary;
+      }
+    }
+  }
+
+  &__option-icon {
+    display: flex;
+    flex: none;
+
+    svg {
+      width: 19px;
+      height: 19px;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 1.7;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+  }
+
+  &__option-label {
+    flex: 1;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  &__option-count {
+    padding: 1px 8px;
+    border-radius: 999px;
+    background-color: $gb-color-component;
+    font-family: $gb-font-mono;
+    font-size: $font-size-large;
+    font-weight: 600;
+    color: $gb-color-disabled;
+  }
+
+  &__option--active &__option-count {
+    background-color: $color-white;
+    color: $gb-color-primary;
+  }
+
+  &__option-badge {
+    padding: 2px 6px;
+    border-radius: $radius-small;
+    background-color: $gb-color-success-soft;
+    font-family: $gb-font-mono;
+    font-size: $font-size-medium;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: $gb-color-success;
+  }
+
+  &__option-tip {
+    display: none;
+  }
+
+  &__footer {
+    margin-top: auto;
+    padding-top: $spacing-large;
+    border-top: 1px solid $gb-color-separator;
+  }
+
+  &--collapsed {
+    width: $gc-sidebar-width-collapsed;
+
+    .gc-sidebar__group-label {
+      height: 8px;
+      padding: 0;
+      overflow: hidden;
+      opacity: 0;
+    }
+
+    .gc-sidebar__option {
+      justify-content: center;
+      padding: 0;
+    }
+
+    .gc-sidebar__option-label,
+    .gc-sidebar__option-count,
+    .gc-sidebar__option-badge {
+      display: none;
+    }
+
+    .gc-sidebar__option:hover .gc-sidebar__option-tip {
+      display: block;
+      position: absolute;
+      left: calc(100% + #{$spacing-large});
+      top: 50%;
+      transform: translateY(-50%);
+      padding: $spacing-medium $spacing-large;
+      border-radius: $radius-medium;
+      background-color: $gb-color-text;
+      box-shadow: $gc-shadow-default;
+      font-size: $font-size-large;
+      font-weight: 600;
+      color: $color-white;
+      white-space: nowrap;
+      z-index: $zlayer-top;
+    }
+  }
+}

--- a/src/components/SidebarFooter/index.tsx
+++ b/src/components/SidebarFooter/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import classNames from "classnames";
+
+type Props = {
+  className?: string;
+  children?: React.ReactNode;
+};
+
+function SidebarFooter({ className = "", children = null }: Props) {
+  const footerClasses = classNames(className, "gc-sidebar__footer");
+
+  return <div className={footerClasses}>{children}</div>;
+}
+
+export default SidebarFooter;

--- a/src/components/SidebarGroup/index.tsx
+++ b/src/components/SidebarGroup/index.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import classNames from "classnames";
+
+type Props = {
+  className?: string;
+  label?: React.ReactNode;
+  children?: React.ReactNode;
+};
+
+function SidebarGroup({
+  className = "",
+  label = null,
+  children = null,
+}: Props) {
+  const groupClasses = classNames(className, "gc-sidebar__group");
+
+  return (
+    <div className={groupClasses}>
+      {label && <div className="gc-sidebar__group-label">{label}</div>}
+      {children}
+    </div>
+  );
+}
+
+export default SidebarGroup;

--- a/src/components/SidebarOption/index.tsx
+++ b/src/components/SidebarOption/index.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import classNames from "classnames";
+
+type Props = {
+  className?: string;
+  label: React.ReactNode;
+  href?: string;
+  icon?: React.ReactNode;
+  isActive?: boolean;
+  count?: React.ReactNode;
+  badge?: React.ReactNode;
+  onClick?: () => void;
+};
+
+function SidebarOption({
+  className = "",
+  label,
+  href = undefined,
+  icon = null,
+  isActive = false,
+  count = undefined,
+  badge = null,
+  onClick = undefined,
+}: Props) {
+  const optionClasses = classNames(className, "gc-sidebar__option", {
+    "gc-sidebar__option--active": isActive,
+  });
+
+  const content = (
+    <>
+      {icon && (
+        <span className="gc-sidebar__option-icon" aria-hidden="true">
+          {icon}
+        </span>
+      )}
+      <span className="gc-sidebar__option-label">{label}</span>
+      {badge && <span className="gc-sidebar__option-badge">{badge}</span>}
+      {count != null && (
+        <span className="gc-sidebar__option-count">{count}</span>
+      )}
+      <span className="gc-sidebar__option-tip">{label}</span>
+    </>
+  );
+
+  if (href) {
+    return (
+      <a
+        className={optionClasses}
+        href={href}
+        onClick={onClick}
+        aria-current={isActive ? "page" : undefined}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={optionClasses}
+      onClick={onClick}
+      aria-current={isActive ? "page" : undefined}
+    >
+      {content}
+    </button>
+  );
+}
+
+export default SidebarOption;

--- a/src/components/SidebarOption/index.tsx
+++ b/src/components/SidebarOption/index.tsx
@@ -38,7 +38,9 @@ function SidebarOption({
       {count != null && (
         <span className="gc-sidebar__option-count">{count}</span>
       )}
-      <span className="gc-sidebar__option-tip">{label}</span>
+      <span className="gc-sidebar__option-tip" aria-hidden="true">
+        {label}
+      </span>
     </>
   );
 

--- a/src/example.scss
+++ b/src/example.scss
@@ -36,6 +36,7 @@
 @import "components/Sample/styles/styles";
 @import "components/SectionHeader/styles/styles";
 @import "components/Separator/styles/styles";
+@import "components/Sidebar/styles/styles";
 @import "components/Scroller/styles/styles";
 @import "components/Switch/styles/mixins";
 @import "components/Switch/styles/styles";

--- a/src/example.tsx
+++ b/src/example.tsx
@@ -26,6 +26,10 @@ import {
   Scroller,
   SegmentedControl,
   Separator,
+  Sidebar,
+  SidebarGroup,
+  SidebarOption,
+  SidebarFooter,
   Skeleton,
   Stat,
   Switch,
@@ -209,6 +213,7 @@ const NAV = [
       { id: "card", label: "Card" },
       { id: "badge", label: "Badge" },
       { id: "navigation", label: "Navigation" },
+      { id: "sidebar", label: "Sidebar" },
       { id: "segmented-control", label: "Segmented control" },
       { id: "stat", label: "Stat" },
       { id: "cover-empty", label: "Cover empty" },
@@ -248,6 +253,7 @@ const TOC = [
   ["card", "Card"],
   ["badge", "Badge"],
   ["navigation", "Navigation"],
+  ["sidebar", "Sidebar"],
   ["segmented-control", "Segmented control"],
   ["stat", "Stat"],
   ["cover-empty", "Cover empty"],
@@ -332,6 +338,65 @@ function JoystickDemo() {
         left: {position.left} / top: {position.top}
       </span>
     </>
+  );
+}
+
+function SidebarDemo() {
+  const [active, setActive] = useState("posts");
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  return (
+    <div className="docs-sidebar-demo">
+      <Button
+        className="gc-btn--outline"
+        onClick={() => setIsCollapsed((value) => !value)}
+      >
+        {isCollapsed ? "Expand" : "Collapse"}
+      </Button>
+      <div className="docs-sidebar-stage">
+        <Sidebar isCollapsed={isCollapsed}>
+          <SidebarGroup label="Content">
+            <SidebarOption
+              label="Posts"
+              icon={<Icons.IconEdit />}
+              count={24}
+              isActive={active === "posts"}
+              onClick={() => setActive("posts")}
+            />
+            <SidebarOption
+              label="Gallery"
+              icon={<Icons.IconImg />}
+              count={312}
+              isActive={active === "gallery"}
+              onClick={() => setActive("gallery")}
+            />
+            <SidebarOption
+              label="Email templates"
+              icon={<Icons.IconMail />}
+              isActive={active === "email"}
+              onClick={() => setActive("email")}
+            />
+          </SidebarGroup>
+          <SidebarGroup label="Support">
+            <SidebarOption
+              label="Helpdesk"
+              icon={<Icons.IconClock />}
+              count={3}
+              badge="new"
+              isActive={active === "helpdesk"}
+              onClick={() => setActive("helpdesk")}
+            />
+          </SidebarGroup>
+          <SidebarFooter>
+            <SidebarOption
+              label="Account"
+              icon={<Icons.IconCheck />}
+              isActive={active === "account"}
+              onClick={() => setActive("account")}
+            />
+          </SidebarFooter>
+        </Sidebar>
+      </div>
+    </div>
   );
 }
 
@@ -1229,8 +1294,39 @@ function App() {
             </Demo>
           </section>
 
-          <section className="docs-section" id="segmented-control">
+          <section className="docs-section" id="sidebar">
             <div className="docs-section-eyebrow">Components / 12</div>
+            <h2 className="docs-section-title">Sidebar</h2>
+            <p className="docs-section-desc">
+              Vertical navigation rail for application shells. Compose it from{" "}
+              <code>SidebarGroup</code> sections, <code>SidebarOption</code>{" "}
+              items with icons, counts and badges, and an optional{" "}
+              <code>SidebarFooter</code> pinned to the bottom. Set{" "}
+              <code>isCollapsed</code> to shrink it to an icons-only rail with
+              hover tooltips.
+            </p>
+            <Demo
+              stageClass="column"
+              code={`<Sidebar isCollapsed={collapsed}>
+  <SidebarGroup label="Content">
+    <SidebarOption label="Posts" icon={<Icons.IconEdit />} count={24} isActive />
+    <SidebarOption label="Gallery" icon={<Icons.IconImg />} count={312} />
+    <SidebarOption label="Email templates" icon={<Icons.IconMail />} />
+  </SidebarGroup>
+  <SidebarGroup label="Support">
+    <SidebarOption label="Helpdesk" icon={<Icons.IconClock />} count={3} badge="new" />
+  </SidebarGroup>
+  <SidebarFooter>
+    <SidebarOption label="Account" icon={<Icons.IconCheck />} />
+  </SidebarFooter>
+</Sidebar>`}
+            >
+              <SidebarDemo />
+            </Demo>
+          </section>
+
+          <section className="docs-section" id="segmented-control">
+            <div className="docs-section-eyebrow">Components / 13</div>
             <h2 className="docs-section-title">Segmented control</h2>
             <p className="docs-section-desc">
               A pill-shaped toggle for switching between a few mutually
@@ -1258,7 +1354,7 @@ function App() {
           </section>
 
           <section className="docs-section" id="stat">
-            <div className="docs-section-eyebrow">Components / 13</div>
+            <div className="docs-section-eyebrow">Components / 14</div>
             <h2 className="docs-section-title">Stat</h2>
             <p className="docs-section-desc">
               A single key figure with a labelled, color-coded dot. Group a few
@@ -1282,7 +1378,7 @@ function App() {
           </section>
 
           <section className="docs-section" id="cover-empty">
-            <div className="docs-section-eyebrow">Components / 14</div>
+            <div className="docs-section-eyebrow">Components / 15</div>
             <h2 className="docs-section-title">Cover empty</h2>
             <p className="docs-section-desc">
               A neutral placeholder for a missing image or empty media slot. It
@@ -1301,7 +1397,7 @@ function App() {
           </section>
 
           <section className="docs-section" id="switch">
-            <div className="docs-section-eyebrow">Components / 15</div>
+            <div className="docs-section-eyebrow">Components / 16</div>
             <h2 className="docs-section-title">Switch</h2>
             <p className="docs-section-desc">
               A toggle for a single on / off setting that takes effect
@@ -1325,7 +1421,7 @@ function App() {
           </section>
 
           <section className="docs-section" id="panel">
-            <div className="docs-section-eyebrow">Components / 16</div>
+            <div className="docs-section-eyebrow">Components / 17</div>
             <h2 className="docs-section-title">Panel</h2>
             <p className="docs-section-desc">
               A composable surface for grouping related content. Combine{" "}
@@ -1363,7 +1459,7 @@ function App() {
           </section>
 
           <section className="docs-section" id="accordion">
-            <div className="docs-section-eyebrow">Components / 17</div>
+            <div className="docs-section-eyebrow">Components / 18</div>
             <h2 className="docs-section-title">Accordion</h2>
             <p className="docs-section-desc">
               A collapsible panel for secondary content. It starts collapsed by
@@ -1384,7 +1480,7 @@ function App() {
           </section>
 
           <section className="docs-section" id="flex">
-            <div className="docs-section-eyebrow">Components / 18</div>
+            <div className="docs-section-eyebrow">Components / 19</div>
             <h2 className="docs-section-title">Flex</h2>
             <p className="docs-section-desc">
               A thin flexbox wrapper. <code>FlexItem</code> children opt into
@@ -1418,7 +1514,7 @@ function App() {
           </section>
 
           <section className="docs-section" id="loader">
-            <div className="docs-section-eyebrow">Components / 19</div>
+            <div className="docs-section-eyebrow">Components / 20</div>
             <h2 className="docs-section-title">Loader</h2>
             <p className="docs-section-desc">
               An indeterminate spinner for blocking waits. The ring mixes white
@@ -1432,7 +1528,7 @@ function App() {
           </section>
 
           <section className="docs-section" id="skeleton">
-            <div className="docs-section-eyebrow">Components / 20</div>
+            <div className="docs-section-eyebrow">Components / 21</div>
             <h2 className="docs-section-title">Skeleton</h2>
             <p className="docs-section-desc">
               A shimmering placeholder line for content that is still loading.
@@ -1453,7 +1549,7 @@ function App() {
           </section>
 
           <section className="docs-section" id="tooltip">
-            <div className="docs-section-eyebrow">Components / 21</div>
+            <div className="docs-section-eyebrow">Components / 22</div>
             <h2 className="docs-section-title">Tooltip</h2>
             <p className="docs-section-desc">
               A small anchored bubble for contextual feedback. It positions
@@ -1474,7 +1570,7 @@ function App() {
           </section>
 
           <section className="docs-section" id="validation">
-            <div className="docs-section-eyebrow">Components / 22</div>
+            <div className="docs-section-eyebrow">Components / 23</div>
             <h2 className="docs-section-title">Validation</h2>
             <p className="docs-section-desc">
               Wraps a form control and reveals a tooltip with the validation
@@ -1499,7 +1595,7 @@ function App() {
           </section>
 
           <section className="docs-section" id="alert">
-            <div className="docs-section-eyebrow">Components / 23</div>
+            <div className="docs-section-eyebrow">Components / 24</div>
             <h2 className="docs-section-title">Alert</h2>
             <p className="docs-section-desc">
               A bordered message box for inline page-level feedback. Styles-only
@@ -1522,7 +1618,7 @@ function App() {
           </section>
 
           <section className="docs-section" id="list">
-            <div className="docs-section-eyebrow">Components / 24</div>
+            <div className="docs-section-eyebrow">Components / 25</div>
             <h2 className="docs-section-title">List</h2>
             <p className="docs-section-desc">
               A bordered stack of rows for simple records. Styles-only primitive
@@ -1545,7 +1641,7 @@ function App() {
           </section>
 
           <section className="docs-section" id="textarea">
-            <div className="docs-section-eyebrow">Components / 25</div>
+            <div className="docs-section-eyebrow">Components / 26</div>
             <h2 className="docs-section-title">Textarea</h2>
             <p className="docs-section-desc">
               Multi-line text input matching the Input styling. Styles-only
@@ -1564,7 +1660,7 @@ function App() {
           </section>
 
           <section className="docs-section" id="led">
-            <div className="docs-section-eyebrow">Components / 26</div>
+            <div className="docs-section-eyebrow">Components / 27</div>
             <h2 className="docs-section-title">LED</h2>
             <p className="docs-section-desc">
               A status light for dashboards and device panels. Add{" "}
@@ -1586,7 +1682,7 @@ function App() {
           </section>
 
           <section className="docs-section" id="joystick">
-            <div className="docs-section-eyebrow">Components / 27</div>
+            <div className="docs-section-eyebrow">Components / 28</div>
             <h2 className="docs-section-title">Joystick</h2>
             <p className="docs-section-desc">
               A draggable two-axis control for hardware-like interfaces. Drag
@@ -1605,7 +1701,7 @@ function App() {
           </section>
 
           <section className="docs-section" id="scroller">
-            <div className="docs-section-eyebrow">Components / 28</div>
+            <div className="docs-section-eyebrow">Components / 29</div>
             <h2 className="docs-section-title">Scroller</h2>
             <p className="docs-section-desc">
               A draggable horizontal slider for scrubbing through a range. Drag

--- a/src/example/styles/_docs.scss
+++ b/src/example/styles/_docs.scss
@@ -662,6 +662,22 @@ body.docs-body {
   color: var(--text-muted);
 }
 
+.docs-sidebar-demo {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  align-items: flex-start;
+  width: 100%;
+}
+
+.docs-sidebar-stage {
+  display: flex;
+  height: 380px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
 .docs-type-row {
   display: grid;
   grid-template-columns: 80px 80px 1fr;

--- a/src/example/styles/_docs.scss
+++ b/src/example/styles/_docs.scss
@@ -673,9 +673,16 @@ body.docs-body {
 .docs-sidebar-stage {
   display: flex;
   height: 380px;
+  width: fit-content;
   border: 1px solid var(--border);
   border-radius: 10px;
-  overflow: hidden;
+
+  // Keep the rail's own corners tidy without an overflow clip, which would
+  // trap the collapsed-mode hover tooltip that extends past the rail edge.
+  .gc-sidebar {
+    border-top-left-radius: 10px;
+    border-bottom-left-radius: 10px;
+  }
 }
 
 .docs-type-row {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,10 @@ import Link from "src/components/Link";
 import Loader from "src/components/Loader";
 import Scroller from "src/components/Scroller";
 import Separator from "src/components/Separator";
+import Sidebar from "src/components/Sidebar";
+import SidebarGroup from "src/components/SidebarGroup";
+import SidebarOption from "src/components/SidebarOption";
+import SidebarFooter from "src/components/SidebarFooter";
 import Tooltip from "src/components/Tooltip";
 import Validation from "src/components/Validation";
 import Logo from "src/components/Logo";
@@ -44,6 +48,10 @@ export {
   Loader,
   Scroller,
   Separator,
+  Sidebar,
+  SidebarGroup,
+  SidebarOption,
+  SidebarFooter,
   Tooltip,
   Validation,
   Logo,

--- a/src/style.scss
+++ b/src/style.scss
@@ -36,6 +36,7 @@
 @import "components/Sample/styles/styles";
 @import "components/SectionHeader/styles/styles";
 @import "components/Separator/styles/styles";
+@import "components/Sidebar/styles/styles";
 @import "components/Scroller/styles/styles";
 @import "components/Switch/styles/mixins";
 @import "components/Switch/styles/styles";


### PR DESCRIPTION
**Business justification:** https://codait.atlassian.net/browse/CODA-109

**Description:**

Adds a composable left-sidebar navigation component family for application shells, adapted from the "Navigation redesign" design (left-sidebar layout).

New public components (all additive — no existing component, class, or variable changes):

- `Sidebar` — `<nav>` rail container. `isCollapsed` toggles `gc-sidebar--collapsed`, shrinking the rail to an icons-only bar, hiding group labels / item text / counts / badges, and revealing a per-item hover tooltip.
- `SidebarGroup` — a titled section (`label`).
- `SidebarOption` — an item that renders an `<a>` when `href` is set, otherwise a `<button type="button">`. Props: `icon`, `isActive` (adds the accent bar + `aria-current="page"`), `count`, `badge`, `onClick`.
- `SidebarFooter` — a bottom-pinned section (`margin-top: auto`).

Public API changes: four new exports from `src/index.ts` (`Sidebar`, `SidebarGroup`, `SidebarOption`, `SidebarFooter`).

Style contract: new `gc-sidebar` BEM block only; styles reuse existing Graphen tokens (`$gb-color-primary`, `$gb-color-info-soft`, `$gb-color-component`, `$gb-color-separator`, `$gb-color-success`, spacing/radius/shadow/mono-font vars). Only the two rail widths are component-local SCSS values. Imported from `src/style.scss` and `src/example.scss`.

Dependencies: none changed.

Compatibility: additive only; downstream compatibility preserved.

Also: adds a live "Sidebar" section to the example app (nav list, TOC, interactive collapse demo) and records the decision in `docs/adr/0003-sidebar-navigation-component.md`.

Checks: `tsc`, `eslint`, `stylelint`, `prettier` all clean; `build:example` compiles. Verified in the browser via the example app — grouped sections, active accent bar, counts, "new" badge, bottom-pinned footer, and the collapsed icons-only rail with a working hover tooltip all render correctly.

**Visual overview:**

Verified via the example app's new **Components / Sidebar** section (`npm run build:example` + `npm run example-run`):

- Expanded rail: `CONTENT` / `SUPPORT` groups, active "Posts" item (info-soft background + brand left accent bar), count pills (24 / 312), a green `NEW` badge on Helpdesk, and "Account" pinned to the footer.
- Collapsed rail (`isCollapsed`): 72px icons-only bar, group labels and item text/counts/badges hidden, active accent bar retained, dark hover tooltip ("Posts") to the right of the rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)