### PR TITLE
CODA-111 - Sidebar overflowing items

### DIFF
--- a/src/components/Sidebar/styles/_styles.scss
+++ b/src/components/Sidebar/styles/_styles.scss
@@ -187,4 +187,15 @@ $gc-sidebar-width-collapsed: 72px;
       z-index: $zlayer-top;
     }
   }
+
+  // On touch devices the hover tooltip the collapsed rail relies on to reveal
+  // item labels never fires, so `overflow: visible` gains nothing to escape
+  // and only lets a rail taller than the viewport spill its icons out of the
+  // block. Contain the rail's own scroll there instead.
+  @media (hover: none) {
+    &--collapsed {
+      overflow-x: hidden;
+      overflow-y: auto;
+    }
+  }
 }


### PR DESCRIPTION
**Business justification:** https://codait.atlassian.net/browse/CODA-111

**Description:**
The collapsed sidebar rail (`.gc-sidebar--collapsed`) used `overflow: visible` so the icon-only hover tooltip could escape past the narrow 72px rail edge. `visible` also removes vertical containment, so on a short viewport a collapsed rail taller than the screen spilled its icons out of the block (reported on mobile).

The escaping tooltip is a hover affordance that never fires on touch devices, so `overflow: visible` gains nothing there. This adds a touch-only `@media (hover: none)` override that contains the rail's own scroll (`overflow-x: hidden; overflow-y: auto`), while hover-device behaviour — the `overflow: visible` rail and the CSS tooltip — is left exactly as-is.

CSS-only change scoped to `gc-sidebar`. No public API, component prop, CSS class, or SCSS variable changes; fully backwards-compatible. Consistent with ADR 0003 (collapsed tooltip stays plain CSS, no fixed positioning), so no ADR update needed.

**Visual overview:**
N/A — touch-only (`@media (hover: none)`) behaviour that browser device emulation does not reliably reproduce. Verified via `stylelint` and SCSS compilation of the emitted media query.