### PR TITLE
CODA-112 - Sidebar sub-groups

### DIFF
--- a/docs/adr/0004-sidebar-submenu-subgroups.md
+++ b/docs/adr/0004-sidebar-submenu-subgroups.md
@@ -1,0 +1,62 @@
+# ADR 0004: Sidebar collapsible sub-groups
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-27
+
+## Context
+
+The `Sidebar` family (ADR 0003) is a flat list of `SidebarOption` items grouped
+under titled `SidebarGroup` sections. Application shells built on Graphen now
+need a second level of navigation: a parent item that expands to reveal its own
+child items (e.g. "Posts" → All posts / Drafts / Scheduled), with the group
+collapsing and expanding in place.
+
+Reusing `SidebarGroup` was rejected — it is a static, always-open, label-only
+section with no interactive header, active state, or collapse behaviour, and it
+cannot host the accent/caret affordances a nested, toggleable parent needs.
+Overloading `SidebarOption` with nested children was also rejected — an option
+renders as a single `<a>`/`<button>`, so its expandable region has to live as a
+sibling, not a descendant, of the clickable header.
+
+## Decision
+
+Add two additive, presentational components on the existing `gc-sidebar` block,
+plus a small expansion affordance on `SidebarOption`:
+
+- `SidebarOption` gains `isExpandable` and `isExpanded`. When `isExpandable` is
+  set it always renders as a `<button>` (never a link), draws a rotating caret
+  (`gc-sidebar__option-caret`, `--expanded` rotates it), suppresses its own
+  `count`, and exposes `aria-expanded`. Existing options are unaffected.
+- `SidebarSubmenu` — the `gc-sidebar__block` wrapper. It renders an expandable
+  `SidebarOption` header and a `gc-sidebar__subnav` region (animated with a
+  `grid-template-rows: 0fr → 1fr` transition) holding the children. Props:
+  `label`, `icon`, `badge`, `isActive`, `hasActiveChild` (adds
+  `gc-sidebar__option--branch`), `isExpanded`, `onToggle`, `children`.
+- `SidebarSubOption` — a child item (`gc-sidebar__suboption`) with an indented
+  left connector rail, `isActive`, optional `count`, and either an `href`
+  (`<a>`) or `onClick` (`<button>`).
+
+Expansion and active state stay presentational props owned by the consumer,
+matching ADR 0003. Styling reuses existing tokens (`$gb-color-primary`,
+`$gb-color-info-soft`, `$gb-color-separator`, `$gb-color-disabled`,
+spacing/radius/mono-font variables); no new design tokens are introduced. In the
+collapsed rail the caret and sub-navigation are hidden. All three exports live in
+`src/index.ts` and reuse the single `gc-sidebar` style namespace.
+
+## Consequences
+
+Graphen gains a two-level sidebar without a new block namespace or any change to
+existing components, classes, or variables — the surface grows by two exports
+(`SidebarSubmenu`, `SidebarSubOption`) and two additive `SidebarOption` props, so
+downstream compatibility is preserved.
+
+Because the collapse animation relies on `grid-template-rows` interpolation, the
+sub-navigation stays in the DOM when closed; the toggle exposes `aria-expanded`
+so assistive tech still reports the collapsed/expanded state. Consumers own the
+expanded and active state and decide when a parent reads as active
+(`isActive`) versus merely containing the active child (`hasActiveChild`).

--- a/src/components/Sidebar/styles/_styles.scss
+++ b/src/components/Sidebar/styles/_styles.scss
@@ -126,6 +126,109 @@ $gc-sidebar-width-collapsed: 72px;
     display: none;
   }
 
+  &__option-caret {
+    display: flex;
+    flex: none;
+    margin-right: -2px;
+    transition: transform 0.16s ease;
+
+    svg {
+      width: 15px;
+      height: 15px;
+      fill: none;
+      stroke: $gb-color-disabled;
+      stroke-width: 2;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    &--expanded {
+      transform: rotate(90deg);
+    }
+  }
+
+  &__option--active &__option-caret svg,
+  &__option--branch &__option-caret svg {
+    stroke: $gb-color-primary;
+  }
+
+  &__block {
+    position: relative;
+  }
+
+  &__subnav {
+    display: grid;
+    // `0fr` (not `0`) keeps the collapsed track a zero fraction so it can
+    // animate to `1fr`; the zero-unit lint rule misreads the grid fraction.
+    grid-template-rows: 0fr; // stylelint-disable-line length-zero-no-unit
+    transition: grid-template-rows 0.2s ease;
+
+    &--open {
+      grid-template-rows: 1fr;
+    }
+  }
+
+  &__subnav-inner {
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  &__suboption {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: $spacing-large;
+    width: 100%;
+    height: 34px;
+    margin-left: 9px;
+    padding: 0 $spacing-large 0 22px;
+    border: 0;
+    border-left: 1.5px solid $gb-color-separator;
+    border-radius: 0 $radius-medium $radius-medium 0;
+    background: none;
+    color: $gb-color-disabled;
+    font: inherit;
+    font-weight: 500;
+    text-align: left;
+    text-decoration: none;
+    cursor: pointer;
+    transition:
+      background-color 0.11s ease,
+      color 0.11s ease,
+      border-color 0.11s ease;
+
+    &:hover {
+      background-color: $gb-color-component;
+      color: $gb-color-text;
+      text-decoration: none;
+    }
+
+    &--active {
+      border-left-color: $gb-color-primary;
+      background-color: $gb-color-info-soft;
+      color: $gb-color-primary;
+      font-weight: 600;
+    }
+  }
+
+  &__suboption-label {
+    flex: 1;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  &__suboption-count {
+    font-family: $gb-font-mono;
+    font-size: $font-size-large;
+    font-weight: 600;
+    color: $gb-color-disabled;
+  }
+
+  &__suboption--active &__suboption-count {
+    color: $gb-color-primary;
+  }
+
   &__footer {
     margin-top: auto;
     padding-top: $spacing-large;
@@ -152,7 +255,9 @@ $gc-sidebar-width-collapsed: 72px;
     }
 
     .gc-sidebar__option-count,
-    .gc-sidebar__option-badge {
+    .gc-sidebar__option-badge,
+    .gc-sidebar__option-caret,
+    .gc-sidebar__subnav {
       display: none;
     }
 

--- a/src/components/SidebarOption/index.tsx
+++ b/src/components/SidebarOption/index.tsx
@@ -7,6 +7,8 @@ type Props = {
   href?: string;
   icon?: React.ReactNode;
   isActive?: boolean;
+  isExpandable?: boolean;
+  isExpanded?: boolean;
   count?: React.ReactNode;
   badge?: React.ReactNode;
   onClick?: () => void;
@@ -18,12 +20,18 @@ function SidebarOption({
   href = undefined,
   icon = null,
   isActive = false,
+  isExpandable = false,
+  isExpanded = false,
   count = undefined,
   badge = null,
   onClick = undefined,
 }: Props) {
   const optionClasses = classNames(className, "gc-sidebar__option", {
     "gc-sidebar__option--active": isActive,
+  });
+
+  const caretClasses = classNames("gc-sidebar__option-caret", {
+    "gc-sidebar__option-caret--expanded": isExpanded,
   });
 
   const content = (
@@ -35,8 +43,15 @@ function SidebarOption({
       )}
       <span className="gc-sidebar__option-label">{label}</span>
       {badge && <span className="gc-sidebar__option-badge">{badge}</span>}
-      {count != null && (
+      {count != null && !isExpandable && (
         <span className="gc-sidebar__option-count">{count}</span>
+      )}
+      {isExpandable && (
+        <span className={caretClasses} aria-hidden="true">
+          <svg viewBox="0 0 24 24">
+            <path d="M9 6l6 6-6 6" />
+          </svg>
+        </span>
       )}
       <span className="gc-sidebar__option-tip" aria-hidden="true">
         {label}
@@ -44,7 +59,9 @@ function SidebarOption({
     </>
   );
 
-  if (href) {
+  // An expandable option toggles its own submenu, so it always renders as a
+  // button even when an href would otherwise make it a link.
+  if (href && !isExpandable) {
     return (
       <a
         className={optionClasses}
@@ -63,6 +80,7 @@ function SidebarOption({
       className={optionClasses}
       onClick={onClick}
       aria-current={isActive ? "page" : undefined}
+      aria-expanded={isExpandable ? isExpanded : undefined}
     >
       {content}
     </button>

--- a/src/components/SidebarSubOption/index.tsx
+++ b/src/components/SidebarSubOption/index.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import classNames from "classnames";
+
+type Props = {
+  className?: string;
+  label: React.ReactNode;
+  href?: string;
+  isActive?: boolean;
+  count?: React.ReactNode;
+  onClick?: () => void;
+};
+
+function SidebarSubOption({
+  className = "",
+  label,
+  href = undefined,
+  isActive = false,
+  count = undefined,
+  onClick = undefined,
+}: Props) {
+  const subOptionClasses = classNames(className, "gc-sidebar__suboption", {
+    "gc-sidebar__suboption--active": isActive,
+  });
+
+  const content = (
+    <>
+      <span className="gc-sidebar__suboption-label">{label}</span>
+      {count != null && (
+        <span className="gc-sidebar__suboption-count">{count}</span>
+      )}
+    </>
+  );
+
+  if (href) {
+    return (
+      <a
+        className={subOptionClasses}
+        href={href}
+        onClick={onClick}
+        aria-current={isActive ? "page" : undefined}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={subOptionClasses}
+      onClick={onClick}
+      aria-current={isActive ? "page" : undefined}
+    >
+      {content}
+    </button>
+  );
+}
+
+export default SidebarSubOption;

--- a/src/components/SidebarSubmenu/index.tsx
+++ b/src/components/SidebarSubmenu/index.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import classNames from "classnames";
+import SidebarOption from "src/components/SidebarOption";
+
+type Props = {
+  className?: string;
+  label: React.ReactNode;
+  icon?: React.ReactNode;
+  badge?: React.ReactNode;
+  isActive?: boolean;
+  hasActiveChild?: boolean;
+  isExpanded?: boolean;
+  onToggle?: () => void;
+  children?: React.ReactNode;
+};
+
+function SidebarSubmenu({
+  className = "",
+  label,
+  icon = null,
+  badge = null,
+  isActive = false,
+  hasActiveChild = false,
+  isExpanded = false,
+  onToggle = undefined,
+  children = null,
+}: Props) {
+  const blockClasses = classNames(className, "gc-sidebar__block");
+
+  const optionClasses = classNames({
+    "gc-sidebar__option--branch": hasActiveChild,
+  });
+
+  const subnavClasses = classNames("gc-sidebar__subnav", {
+    "gc-sidebar__subnav--open": isExpanded,
+  });
+
+  return (
+    <div className={blockClasses}>
+      <SidebarOption
+        className={optionClasses}
+        label={label}
+        icon={icon}
+        badge={badge}
+        isActive={isActive}
+        isExpandable
+        isExpanded={isExpanded}
+        onClick={onToggle}
+      />
+      <div className={subnavClasses}>
+        <div className="gc-sidebar__subnav-inner" role="group">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SidebarSubmenu;

--- a/src/example.tsx
+++ b/src/example.tsx
@@ -29,6 +29,8 @@ import {
   Sidebar,
   SidebarGroup,
   SidebarOption,
+  SidebarSubmenu,
+  SidebarSubOption,
   SidebarFooter,
   Skeleton,
   Stat,
@@ -342,8 +344,11 @@ function JoystickDemo() {
 }
 
 function SidebarDemo() {
-  const [active, setActive] = useState("posts");
+  const [active, setActive] = useState("posts-all");
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isPostsExpanded, setIsPostsExpanded] = useState(true);
+  const postsChildren = ["posts-all", "posts-drafts", "posts-scheduled"];
+  const hasActivePostsChild = postsChildren.includes(active);
   return (
     <div className="docs-sidebar-demo">
       <Button
@@ -355,13 +360,33 @@ function SidebarDemo() {
       <div className="docs-sidebar-stage">
         <Sidebar isCollapsed={isCollapsed}>
           <SidebarGroup label="Content">
-            <SidebarOption
+            <SidebarSubmenu
               label="Posts"
               icon={<Icons.IconEdit />}
-              count={24}
-              isActive={active === "posts"}
-              onClick={() => setActive("posts")}
-            />
+              isExpanded={isPostsExpanded}
+              hasActiveChild={hasActivePostsChild}
+              isActive={hasActivePostsChild && !isPostsExpanded}
+              onToggle={() => setIsPostsExpanded((value) => !value)}
+            >
+              <SidebarSubOption
+                label="All posts"
+                count={24}
+                isActive={active === "posts-all"}
+                onClick={() => setActive("posts-all")}
+              />
+              <SidebarSubOption
+                label="Drafts"
+                count={5}
+                isActive={active === "posts-drafts"}
+                onClick={() => setActive("posts-drafts")}
+              />
+              <SidebarSubOption
+                label="Scheduled"
+                count={2}
+                isActive={active === "posts-scheduled"}
+                onClick={() => setActive("posts-scheduled")}
+              />
+            </SidebarSubmenu>
             <SidebarOption
               label="Gallery"
               icon={<Icons.IconImg />}
@@ -1301,7 +1326,9 @@ function App() {
               Vertical navigation rail for application shells. Compose it from{" "}
               <code>SidebarGroup</code> sections, <code>SidebarOption</code>{" "}
               items with icons, counts and badges, and an optional{" "}
-              <code>SidebarFooter</code> pinned to the bottom. Set{" "}
+              <code>SidebarFooter</code> pinned to the bottom. Nest a{" "}
+              <code>SidebarSubmenu</code> with <code>SidebarSubOption</code>{" "}
+              children to build a collapsible sub-group. Set{" "}
               <code>isCollapsed</code> to shrink it to an icons-only rail with
               hover tooltips.
             </p>
@@ -1309,7 +1336,18 @@ function App() {
               stageClass="column"
               code={`<Sidebar isCollapsed={collapsed}>
   <SidebarGroup label="Content">
-    <SidebarOption label="Posts" icon={<Icons.IconEdit />} count={24} isActive />
+    <SidebarSubmenu
+      label="Posts"
+      icon={<Icons.IconEdit />}
+      isExpanded={postsExpanded}
+      hasActiveChild={active.startsWith("posts-")}
+      isActive={active.startsWith("posts-") && !postsExpanded}
+      onToggle={() => setPostsExpanded((value) => !value)}
+    >
+      <SidebarSubOption label="All posts" count={24} isActive />
+      <SidebarSubOption label="Drafts" count={5} />
+      <SidebarSubOption label="Scheduled" count={2} />
+    </SidebarSubmenu>
     <SidebarOption label="Gallery" icon={<Icons.IconImg />} count={312} />
     <SidebarOption label="Email templates" icon={<Icons.IconMail />} />
   </SidebarGroup>

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ import Separator from "src/components/Separator";
 import Sidebar from "src/components/Sidebar";
 import SidebarGroup from "src/components/SidebarGroup";
 import SidebarOption from "src/components/SidebarOption";
+import SidebarSubmenu from "src/components/SidebarSubmenu";
+import SidebarSubOption from "src/components/SidebarSubOption";
 import SidebarFooter from "src/components/SidebarFooter";
 import Tooltip from "src/components/Tooltip";
 import Validation from "src/components/Validation";
@@ -51,6 +53,8 @@ export {
   Sidebar,
   SidebarGroup,
   SidebarOption,
+  SidebarSubmenu,
+  SidebarSubOption,
   SidebarFooter,
   Tooltip,
   Validation,


### PR DESCRIPTION
**Business justification:** https://codait.atlassian.net/browse/CODA-112

**Description:**

Adds collapsible **sub-groups** to the `Sidebar` family — a parent option that expands to reveal its own child items — as an additive extension of the existing `gc-sidebar` block (following ADR 0003's single-namespace, presentational-props approach).

Public API changes (all additive):
- **`SidebarOption`** — new `isExpandable` and `isExpanded` props. When `isExpandable` it always renders as a `<button>`, draws a rotating caret, exposes `aria-expanded`, and suppresses its own `count`. Existing options are unchanged.
- **`SidebarSubmenu`** *(new, exported)* — a `gc-sidebar__block` wrapper that renders an expandable `SidebarOption` header plus a `gc-sidebar__subnav` region animated via a `grid-template-rows: 0fr → 1fr` transition. Props: `label`, `icon`, `badge`, `isActive`, `hasActiveChild`, `isExpanded`, `onToggle`, `children`.
- **`SidebarSubOption`** *(new, exported)* — a `gc-sidebar__suboption` child item with the indented left connector rail, `isActive`, optional `count`, and `href`/`onClick`.

Style contract: new classes live under the existing `gc-sidebar` namespace and reuse existing tokens (`$gb-color-primary`, `$gb-color-info-soft`, `$gb-color-separator`, `$gb-color-disabled`, spacing/radius/mono-font) — **no new design tokens**. The collapsed icons-only rail hides the caret and sub-navigation.

Compatibility: no existing component, class, or variable changed; the public surface grows by two exports and two `SidebarOption` props. No dependency changes.

Docs/examples: sub-groups demoed in the Sidebar example (`src/example.tsx`), and decision recorded in `docs/adr/0004-sidebar-submenu-subgroups.md`.

Checks: `make lint` passes (tsc, ESLint, Prettier, stylelint); example bundle builds.

**Visual overview:**

Verified in the example app (`#sidebar` demo). Three states confirmed:
- **Expanded sub-group** — "Posts" with a down caret; active child "All posts" highlighted with the blue accent rail; "Drafts"/"Scheduled" muted.
- **Collapsed sub-group** — toggling "Posts" hides the children; because a child is active while collapsed, the parent shows the full active highlight and a right-facing blue caret.
- **Collapsed icons-only rail** — the caret and sub-navigation are hidden; the parent icon keeps its active state.

_Screenshots of each state were captured during verification but are not embedded here (image attachments must be dragged into the PR in the GitHub UI). Reviewers can reproduce them by running the example app and opening the Sidebar section._
